### PR TITLE
Major detection bugs fixed

### DIFF
--- a/FeatureExtractor.py
+++ b/FeatureExtractor.py
@@ -115,9 +115,15 @@ class FeatureExtractor():
         else:
             self.NCC = self.calc_NCC(
                 self.template_feature_map.numpy(), self.image_feature_map.numpy())
+        max_i = self.NCC.shape[0] - 1
+        max_j = self.NCC.shape[1] - 1
 
+        # Lower -> usually lower threshold is more relaxed
         if threshold is None:
             threshold = 0.95 * np.max(self.NCC)
+        else:
+            threshold = threshold * np.max(self.NCC)
+
         max_indices = np.array(np.where(self.NCC > threshold)).T
         print("detected boxes: {}".format(len(max_indices)))
 
@@ -127,6 +133,12 @@ class FeatureExtractor():
 
         for max_index in max_indices:
             i_star, j_star = max_index
+
+            # Avoids overflow
+            if i_star >= max_i:
+                i_star -= 1
+            if j_star >= max_j:
+                j_star -= 1
 
             # Broadcasting fails if NCC_part is not (3,4) of shape
             NCC_part = np.zeros([3,4])

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ python run.py [sample_image_path] [template_image_path] --use_cuda --use_cython
 
 # Using Cython 
 
-Using Cython requires you to build the files in the `cython_files` folder. To build the same, please use: 
+Using Cython requires you to build the files in the `cython_files` folder. To build the same, please use the following command in the `cython_files folder`: 
 
 ```
 python setup.py build_ext -i

--- a/README.md
+++ b/README.md
@@ -18,7 +18,21 @@ python run.py [sample_image_path] [template_image_path] --use_cuda --use_cython
 * add --use_cuda option to use GPU
 * add --use_cython option to execute with cython
 
-result image will be saved as result.png
+# Using Cython 
+
+Using Cython requires you to build the files in the `cython_files` folder. To build the same, please use: 
+
+```
+python setup.py build_ext -i
+```
+
+If your Python version is >3.8, you might need to use a forced build: 
+
+```
+python setup.py build_ext -i -f
+```
+
+The result image will be saved as result.png.
 
 # Example
 ```


### PR DESCRIPTION
The changes are as follows: 

1. `NCC_part` had a tendency to go out of index in some type of images. That has been fixed using edge case checkers. 
2. Added an option to provide a manual threshold during the commandline argument. 
3. Added Cython error fixed command in the README.md file. This will help us build the Cython files in modern Python renditions. 
4. Re-factored code. 
5. Avoided potential issues of running into NaNs by adding an eps during matrix/tensor operations. 

**Credits:** Some of the code has been taken from [this repository](https://github.com/wakanawakana/robustTemplateMatching), and I have cleaned it, and done extensive manual QA testing. 

Thank you, 
Arka Mukherjee 